### PR TITLE
Factor out Turing functionality into package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,6 @@ NonlinearSolveBase = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
-Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
 Accessors = "0.1"
@@ -31,7 +30,6 @@ NonlinearSolveBase = "1"
 Random = "1"
 SciMLBase = "2"
 SimpleNonlinearSolve = "2"
-Turing = "0.32,0.33,0.34,0.35,0.36,0.37,0.38,0.39"
 julia = "1.11"
 
 [sources]

--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ xs = rand(5)
 ysmeas = f.(xs, [θtrue]) .+ rand.(noises)
 
 # find a probabilistic description of θ either as samples or as a distribution
-# currently we provide three methods
-for est in [MCMCEstimator(),
-            LinearApproxEstimator(),
+# currently we provide three methods (MCMCEstimator requires the Turing extension)
+for est in [LinearApproxEstimator(),
             LSQEstimator()]
     # either
     samples =  predictsamples(est, f, xs, ysmeas, paramprior, noisemodel, 100)
@@ -53,7 +52,9 @@ The conversion between samples and a distribution can be done automatically via 
 ![Estimator Overview](docs/src/assets/distribution_graph/distribution_graph.png)
 
 ### MCMCEstimator
-The `MCMCEstimator` simply phrases the problem as a Monte-Carlo Markov-Chain inference problem, which we solve using the `NUTS` algorithm provided by `Turing.jl`.
+The `MCMCEstimator` has been moved to a separate extension package `ProbabilisticParameterEstimatorsTuringExt` to avoid requiring `Turing.jl` as a dependency for the main package.
+To use the `MCMCEstimator`, please install the extension package and use `using ProbabilisticParameterEstimatorsTuringExt`.
+The estimator simply phrases the problem as a Monte-Carlo Markov-Chain inference problem, which we solve using the `NUTS` algorithm provided by `Turing.jl`.
 Therefore `predictdist(::MCMCEstimator, f, xs, ys, paramprior, noisemodel, nsamples)` will create `nsamples` samples (after skipping a number of warmup steps).
 `predictdist(::MCMCEstimator, f, xs, ys, paramprior, noisemodel, nsamples)` will do the same, and then fit a `MvNormal` distribution.
 

--- a/ext/ProbabilisticParameterEstimatorsTuringExt.jl
+++ b/ext/ProbabilisticParameterEstimatorsTuringExt.jl
@@ -1,0 +1,78 @@
+module ProbabilisticParameterEstimatorsTuringExt
+
+using ProbabilisticParameterEstimators
+using Turing
+using Turing: @model, sample, NUTS
+using Distributions: Sampleable, MvNormal, fit
+using LinearAlgebra: diag
+using Logging
+using Logging: ConsoleLogger, Warn, global_logger
+using Accessors: @set
+
+# Re-export the MCMCEstimator type and related functions
+export MCMCEstimator, predictsamples, predictdist
+
+"""
+    struct MCMCEstimator{ST<:Turing.InferenceAlgorithm, SAT<:NamedTuple} <: EstimationMethod
+
+The `MCMCEstimator` simply phrases the problem as a Monte-Carlo Markov-Chain inference
+problem, which we solve using `Turing.jl`. Therefore, predictions will always first create
+samples (after skipping a number of warmup steps), to which a distribution may be fitted.
+
+See also [`predictdist`](@ref) and [`predictsamples`](@ref).
+
+# Fields
+$(TYPEDFIELDS)
+"""
+@kwdef struct MCMCEstimator{ST <: Turing.InferenceAlgorithm, SAT <: NamedTuple} <:
+              ProbabilisticParameterEstimators.EstimationMethod
+    "Inference algorithm type for MCMC sampling. Defaults to `NUTS`."
+    samplealg::ST = NUTS()
+
+    """
+    kwargs passed to `Turing.sample`. 
+    Defaults to `(; drop_warmup=true, progress=false, verbose=false)`.
+    """
+    sampleargs::SAT = (; drop_warmup = true, progress = false, verbose = false)
+end
+
+ProbabilisticParameterEstimators.solvealg(est::MCMCEstimator) = est.samplealg
+ProbabilisticParameterEstimators.solveargs(est::MCMCEstimator) = est.sampleargs
+
+@model function bayesianmodel(estimator::MCMCEstimator, f, xs, ysmeas,
+        paramprior::Sampleable, noisemodel::ProbabilisticParameterEstimators.NoiseModel)
+    θ ~ paramprior
+    ys = ProbabilisticParameterEstimators.maybeflatten(f.(xs, [θ]))
+    ysmeas ~ ProbabilisticParameterEstimators.ShiftedDistribution(
+        ProbabilisticParameterEstimators.mvnoisedistribution(noisemodel), ys)
+    return
+end
+
+function ProbabilisticParameterEstimators.predictsamples(est::MCMCEstimator, f, xs, ysmeas,
+        paramprior::Sampleable, noisemodel::ProbabilisticParameterEstimators.NoiseModel, nsamples::Int)
+    # we used to have this `with_logger` closure, however it's giving JET trouble
+    # correctly inferring the type of `est` somehow.
+    # chain = with_logger(ConsoleLogger(Warn)) do  # ignore "Info" outputs.
+    original_logger = global_logger() # Store the current global logger
+    chain = try
+        global_logger(ConsoleLogger(stderr, Logging.Warn))
+        alg = ProbabilisticParameterEstimators.solvealg(est)
+        sample(bayesianmodel(est, f, xs, ProbabilisticParameterEstimators.maybeflatten(ysmeas), paramprior, noisemodel),
+            alg, nsamples;
+            ProbabilisticParameterEstimators.solveargs(est)...)
+    finally
+        global_logger(original_logger) # Always restore the original logger
+    end
+    d = length(paramprior)
+    θsamples = stack([chain[Symbol("θ[$i]")][:] for i in 1:d]; dims = 1)
+    eachcol(θsamples)
+end
+
+function ProbabilisticParameterEstimators.predictdist(
+        est::MCMCEstimator, f, xs, ys_meas, paramprior::Sampleable, noisemodel::ProbabilisticParameterEstimators.NoiseModel;
+        nsamples::Int = 100)
+    samples = ProbabilisticParameterEstimators.predictsamples(est, f, xs, ys_meas, paramprior, noisemodel, nsamples)
+    fit(MvNormal, parent(samples))
+end
+
+end # module ProbabilisticParameterEstimatorsTuringExt

--- a/ext/Project.toml
+++ b/ext/Project.toml
@@ -1,0 +1,13 @@
+name = "ProbabilisticParameterEstimatorsTuringExt"
+uuid = "d0f0d3a4-8c8d-4f8b-9e1d-4e0ddfe7e1e1"
+authors = ["Romeo Valentin <romeov@stanford.edu>"]
+version = "0.8.1"
+
+[deps]
+ProbabilisticParameterEstimators = "0098cf3f-3e1e-4f11-b01c-dd9dec1b3374"
+Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
+
+[compat]
+ProbabilisticParameterEstimators = "0.8"
+Turing = "0.32,0.33,0.34,0.35,0.36,0.37,0.38,0.39"
+julia = "1.11"

--- a/src/ProbabilisticParameterEstimators.jl
+++ b/src/ProbabilisticParameterEstimators.jl
@@ -3,8 +3,6 @@ import BlockDiagonals: BlockDiagonal
 import LinearAlgebra: Diagonal, lu, diag, I, cholesky, norm
 import Distributions: Normal, MvNormal, var, cov, fit, Distribution, Univariate, Continuous,
                       product_distribution, Sampleable
-import Turing
-import Turing: @model, sample, NUTS
 import Logging
 import Logging: with_logger, ConsoleLogger, Warn, global_logger
 import Accessors: @set
@@ -21,8 +19,7 @@ using DocStringExtensions
 import Base: show
 
 export UncorrGaussianNoiseModel, CorrGaussianNoiseModel, UncorrProductNoiseModel
-export MCMCEstimator, LSQEstimator, LinearApproxEstimator
-export predictsamples, predictdist
+export LSQEstimator, LinearApproxEstimator
 export mvnoisedistribution, covmatrix
 
 """


### PR DESCRIPTION
- Move MCMCEstimator and related functionality to ProbabilisticParameterEstimatorsTuringExt extension
- Remove Turing dependency from main package
- Update README to document the extension usage
- Create Project.toml for the extension with appropriate dependencies